### PR TITLE
fix(web): forked sessions become read-only when reopened

### DIFF
--- a/web/public/js/chat.js
+++ b/web/public/js/chat.js
@@ -1642,12 +1642,14 @@ document.addEventListener("alpine:init", () => {
         const session = await fetchJson(`/api/sessions/${sessionId}`);
         this.applySession(session);
 
-        // Auto-start RPC for empty sessions so they're immediately usable
-        const messageCount = session.stats?.messageCount ?? session.messageCount ?? 0;
+        // Auto-start RPC so the session is immediately usable (not read-only)
         const sessionFile = this.getSessionFile(sessionId);
-        if (messageCount === 0 && sessionFile) {
+        if (sessionFile) {
           this.startRpcSession(sessionFile);
-          this.enterMaximized();
+          const messageCount = session.stats?.messageCount ?? session.messageCount ?? 0;
+          if (messageCount === 0) {
+            this.enterMaximized();
+          }
         }
       } catch (error) {
         this.error = error.message ?? "Failed to load session";


### PR DESCRIPTION
## Summary

- Forked sessions become read-only when reopened via the session list
- Root cause: `selectSession()` only calls `startRpcSession()` when `messageCount === 0` — a forked session already has messages, so RPC never starts
- Fix: always start RPC when a session file exists; keep `enterMaximized()` gated on empty sessions so existing conversations don't jump to fullscreen

Note: forking itself works fine — `forkSession()` calls `startRpcSession()` unconditionally. The bug only hits when re-opening the forked session later via `selectSession()`.

## Test plan

- [ ] Fork a conversation in the web UI
- [ ] Navigate back to the session list
- [ ] Click on the forked session
- [ ] Verify the input box appears and the session is editable (not read-only)
- [ ] Open a brand new (empty) session and verify it still auto-maximizes