### PR TITLE
fix(web): resolve npm prefix dynamically for nvm compatibility

### DIFF
--- a/web/server.ts
+++ b/web/server.ts
@@ -143,16 +143,15 @@ async function loadPiSessionManagerModule(): Promise<{
       }
 
       const homeDir = process.env.HOME ?? "";
-      const fallbackPath = path.join(
-        homeDir,
-        ".npm-global",
-        "lib",
-        "node_modules",
-        "@mariozechner",
-        "pi-coding-agent",
-        "dist",
-        "index.js"
-      );
+      // Resolve actual npm prefix (supports nvm), fall back to ~/.npm-global
+      let prefix = path.join(homeDir, ".npm-global");
+      try {
+        const { execSync } = await import("child_process");
+        prefix = execSync("npm config get prefix", { encoding: "utf-8" }).trim();
+      } catch {
+        // npm not available, use default prefix
+      }
+      const fallbackPath = path.join(prefix, "lib", "node_modules", "@mariozechner", "pi-coding-agent", "dist", "index.js");
       const mod = await import(pathToFileURL(fallbackPath).href);
       if (!mod?.SessionManager) {
         throw new Error("SessionManager export not found in pi-coding-agent module");


### PR DESCRIPTION
## Summary

- The pi-coding-agent fallback path in `loadPiSessionManagerModule()` is hardcoded to `~/.npm-global/...`
- This fails for users with nvm (or any custom npm prefix), because global packages live under the nvm-managed prefix (e.g. `~/.nvm/versions/node/v24.13.1/...`)
- Fix: use `npm config get prefix` to resolve the actual prefix at runtime, falling back to `~/.npm-global` if npm is not available

## Test plan

- [ ] Verify on a system with nvm that pi-coding-agent module loads correctly
- [ ] Verify on a system without nvm that the `~/.npm-global` fallback still works
- [ ] Verify that if npm is not on PATH, the catch block fires and falls back gracefully