### PR TITLE
fix(cli): resolve full path to pi for nvm compatibility

### DIFF
--- a/cli/commands/doctor.ts
+++ b/cli/commands/doctor.ts
@@ -65,12 +65,14 @@ Options:
 }
 
 function gatherDoctorInput(): DoctorInput {
+  // Try PATH first, fall back to node's bin directory (nvm support)
+  const piInfo = getBinaryInfo("pi");
   return {
     nodeVersion: getVersion("node", "--version"),
     binaries: {
       tmux: getBinaryInfo("tmux"),
       git: getBinaryInfo("git"),
-      pi: getBinaryInfo("pi"),
+      pi: piInfo.exists ? piInfo : getBinaryInfo(path.join(path.dirname(process.execPath), "pi")),
     },
     configFiles: getConfigFileStatus(),
     moduleFiles: getModuleFileStatus(),

--- a/cli/commands/start.ts
+++ b/cli/commands/start.ts
@@ -182,9 +182,11 @@ function removeNotification(): void {
 function ensureTmuxSession(): void {
   if (tmuxSessionExists()) return;
 
+  // Resolve full path to pi so tmux can find it without nvm in PATH
+  const piPath = path.join(path.dirname(process.execPath), "pi");
   const r = spawnSync(
     "tmux",
-    [...tmuxBaseArgs(), "new-session", "-d", "-s", SESSION_NAME, "-c", RHO_DIR, "pi -c"],
+    [...tmuxBaseArgs(), "new-session", "-d", "-s", SESSION_NAME, "-c", RHO_DIR, `${piPath} -c`],
     { stdio: "ignore" },
   );
   if (r.status !== 0) {


### PR DESCRIPTION
Closes #7

## Summary

- \`rho start\` spawns a tmux session with \`pi -c\`, but tmux gets a fresh shell without nvm in PATH, so \`pi\` is not found and the session dies immediately
- \`rho doctor\` also fails to find \`pi\` in the same scenario
- Fix: derive pi's full path from \`process.execPath\` (pi is in the same bin directory as node when installed globally via npm)
- No subprocesses, no \`which\`, no \`execSync\` — just \`path.join(path.dirname(process.execPath), "pi")\`

## Changes

- **cli/commands/start.ts**: use full pi path in tmux \`new-session\` command
- **cli/commands/doctor.ts**: fall back to full pi path if \`pi\` not found in PATH

## Test plan

- [ ] On a system with nvm: \`rho start\` creates tmux session successfully
- [ ] On a system with nvm: \`rho doctor\` shows pi as found
- [ ] On a system without nvm: both commands still work (PATH lookup succeeds first)