### PR TITLE
fix(heartbeat): close tmux window after check-in completes

### DIFF
--- a/extensions/rho/index.ts
+++ b/extensions/rho/index.ts
@@ -1095,7 +1095,7 @@ function runHeartbeatInTmux(prompt: string, modelFlags?: string): boolean {
   const target = `${sessionName}:${HEARTBEAT_WINDOW_NAME}`;
   const promptArg = `@${HEARTBEAT_PROMPT_FILE}`;
   const flags = modelFlags ? ` ${modelFlags}` : "";
-  const command = `clear; RHO_SUBAGENT=1 pi --no-session${flags} ${shellEscape(promptArg)}; rm -f ${shellEscape(HEARTBEAT_PROMPT_FILE)}`;
+  const command = `clear; RHO_SUBAGENT=1 pi -p --no-session${flags} ${shellEscape(promptArg)}; rm -f ${shellEscape(HEARTBEAT_PROMPT_FILE)}; exit`;
 
   try {
     if (!heartbeatWindowExists(sessionName)) {


### PR DESCRIPTION
Closes #8

## Summary

- The heartbeat subagent tmux window stays open indefinitely after completing its check-in
- pi remains in interactive mode after executing the prompt, and the shell stays alive
- Fix: add `-p` flag (non-interactive/print mode) so pi exits after the prompt, and append `; exit` to close the shell and tmux window

Works cleanly with the existing `heartbeatWindowExists()` check — next heartbeat simply creates a new window.

## Test plan

- [ ] Trigger a heartbeat and verify the tmux window closes automatically after check-in completes
- [ ] Verify next heartbeat creates a new window and runs successfully
- [ ] Verify that killing a running heartbeat (via `respawn-pane -k`) still works