### PR TITLE
fix(heartbeat): prefer cheapest model over session model

### DIFF
--- a/extensions/rho/index.ts
+++ b/extensions/rho/index.ts
@@ -1613,15 +1613,15 @@ export default function (pi: ExtensionAPI) {
       }
     }
 
-    if (ctx.model) {
-      const apiKey = await ctx.modelRegistry.getApiKey(ctx.model);
-      if (apiKey) return `--provider ${shellEscape(ctx.model.provider)} --model ${shellEscape(ctx.model.id)} --thinking off`;
-    }
-
     try {
       const resolved = await resolveHeartbeatModel(ctx);
       if (resolved) return `--provider ${shellEscape(resolved.provider)} --model ${shellEscape(resolved.model)} --thinking off`;
     } catch { /* ignore */ }
+
+    if (ctx.model) {
+      const apiKey = await ctx.modelRegistry.getApiKey(ctx.model);
+      if (apiKey) return `--provider ${shellEscape(ctx.model.provider)} --model ${shellEscape(ctx.model.id)} --thinking off`;
+    }
 
     return "";
   };


### PR DESCRIPTION
Closes #9

## Summary

- \`buildModelFlags()\` picks the heartbeat model in this order: pinned model -> session model -> cheapest available
- \`ctx.model\` (session model) is always set, so \`resolveHeartbeatModel()\` (cheapest) is never reached — it's dead code
- This means heartbeats run on expensive models (e.g. Opus) for simple memory-clean tasks that Haiku can handle
- Fix: swap the fallback order so cheapest available model is tried before the session model

New order: pinned model -> cheapest available -> session model (last resort)

## Test plan

- [ ] Verify heartbeat uses a cheap model (e.g. Haiku) when no pinned model is set
- [ ] Verify pinned model still takes priority when configured
- [ ] Verify session model is used as fallback if \`resolveHeartbeatModel()\` fails