### PR TITLE
fix(web): stop orphaned RPC processes on disconnect, reuse sessions

### DIFF
--- a/web/server.ts
+++ b/web/server.ts
@@ -100,6 +100,9 @@ function subscribeToRpcSession(ws: WSContext<WebSocket>, sessionId: string): voi
       if (wsSubscriptions && wsSubscriptions.size === 0) {
         rpcSessionSubscribers.delete(ws);
       }
+      if (!rpcManager.hasSubscribers(sessionId)) {
+        rpcManager.stopSession(sessionId);
+      }
     }
   });
 
@@ -112,10 +115,18 @@ function clearRpcSubscriptions(ws: WSContext<WebSocket>): void {
     return;
   }
 
+  const sessionIds = [...subscriptions.keys()];
   for (const unsubscribe of subscriptions.values()) {
     unsubscribe();
   }
   rpcSessionSubscribers.delete(ws);
+
+  // Stop sessions that have no remaining subscribers
+  for (const sessionId of sessionIds) {
+    if (!rpcManager.hasSubscribers(sessionId)) {
+      rpcManager.stopSession(sessionId);
+    }
+  }
 }
 
 function extractSessionFile(payload: WSIncomingMessage): string | null {
@@ -869,7 +880,6 @@ app.get(
       }
 
       let sessionId = typeof payload.sessionId === "string" ? payload.sessionId.trim() : "";
-      let sessionStarted = false;
 
       if (!sessionId) {
         const sessionFile = extractSessionFile(payload);
@@ -881,13 +891,26 @@ app.get(
           return;
         }
 
-        try {
-          sessionId = rpcManager.startSession(sessionFile);
-          subscribeToRpcSession(ws, sessionId);
-          sessionStarted = true;
-          sendWsMessage(ws, { type: "session_started", sessionId, sessionFile });
-        } catch (error) {
-          sendWsMessage(ws, { type: "error", message: (error as Error).message ?? "Failed to start RPC session" });
+        // Reuse existing RPC process for the same session file
+        const existingId = rpcManager.findSessionByFile(sessionFile);
+        if (existingId) {
+          sessionId = existingId;
+        } else {
+          try {
+            sessionId = rpcManager.startSession(sessionFile);
+          } catch (error) {
+            sendWsMessage(ws, { type: "error", message: (error as Error).message ?? "Failed to start RPC session" });
+            return;
+          }
+        }
+        subscribeToRpcSession(ws, sessionId);
+        sendWsMessage(ws, { type: "session_started", sessionId, sessionFile });
+        if (existingId) {
+          rpcManager.sendCommand(sessionId, { type: "get_state" });
+        }
+        // Skip the switch_session command — either startSession() already
+        // sent it, or we're reusing a session already on the right file
+        if (command.type === "switch_session") {
           return;
         }
       } else {
@@ -897,11 +920,6 @@ app.get(
           sendWsMessage(ws, createSessionNotFoundError(sessionId));
           return;
         }
-      }
-
-      const isBootstrapSwitch = sessionStarted && command.type === "switch_session";
-      if (isBootstrapSwitch) {
-        return;
       }
 
       try {


### PR DESCRIPTION
Closes #15

## Problem

Each time the web UI opens a session (page refresh, tab switch, session navigation), a new `pi --mode rpc` process is spawned (~170MB RAM each). When the WebSocket disconnects, `clearRpcSubscriptions()` only removes event handlers — it never calls `stopSession()`. Orphaned processes linger until the 10-minute idle timeout.

Additionally, `stopSession()` checked `process.killed` to decide whether to escalate to SIGKILL, but `process.killed` is set when `.kill()` is called (signal sent), not when the process exits. SIGKILL escalation never fired, so processes that ignored SIGTERM lived forever.

On a 4GB VPS after normal usage, this easily reaches 15+ pi processes / 2.8GB RAM.

## Root causes

1. **No cleanup on disconnect** — `clearRpcSubscriptions()` unsubscribes from events but doesn't stop the process. Same leak path exists in the `subscribeToRpcSession` error handler (broken pipe scenario).

2. **No session reuse** — `rpcManager.startSession()` always spawns a new process. The sessions Map is keyed by random UUID, not sessionFile, so there's no deduplication.

3. **SIGKILL never fires** — `process.killed` means "signal was sent", not "process exited". After SIGTERM, `process.killed` is already true, so the SIGKILL timeout is a no-op.

## Fix

**rpc-manager.ts**:
- `findSessionByFile()` — find existing process for a session file (enables reuse)
- `hasSubscribers()` — check if anyone is still listening (enables cleanup)
- `exited` flag on SessionState — track actual process exit for reliable SIGKILL escalation
- `try/catch` on SIGKILL — handles race condition where process exits between check and kill

**server.ts**:
- `clearRpcSubscriptions()`: after unsubscribing, stop sessions with zero remaining subscribers
- `subscribeToRpcSession` error handler: same orphan check on send failure
- WebSocket handler: reuse existing RPC process for the same session file, send `get_state` to hydrate reconnecting tabs

## Test plan

- [ ] Open a session, navigate away, verify pi process is stopped immediately (not lingering for 10 min)
- [ ] Open same session in two tabs — verify single pi process is shared
- [ ] Close one tab — verify process stays alive for the other tab
- [ ] Close both tabs — verify process is stopped
- [ ] Page refresh — verify no duplicate process spawned
- [ ] Kill a pi process that ignores SIGTERM — verify SIGKILL fires after 2 seconds