### PR TITLE
fix(telegram): resolve TS strict mode errors in api.ts

### DIFF
--- a/extensions/telegram/api.ts
+++ b/extensions/telegram/api.ts
@@ -214,7 +214,7 @@ export class TelegramClient {
     if (value instanceof Blob) {
       blob = value;
     } else if (value instanceof Uint8Array) {
-      blob = new Blob([value], { type: mimeType ?? "application/octet-stream" });
+      blob = new Blob([value as BlobPart], { type: mimeType ?? "application/octet-stream" });
     } else {
       blob = new Blob([value], { type: mimeType ?? "application/octet-stream" });
     }
@@ -222,7 +222,7 @@ export class TelegramClient {
     form.append(fieldName, blob, filename);
   }
 
-  private async call<T>(method: string, body: Record<string, unknown>): Promise<T> {
+  private async call<T>(method: string, body: Record<string, unknown> | object): Promise<T> {
     const response = await fetch(`${this.baseUrl}/${method}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Fixes 4 pre-existing TypeScript strict mode errors in `extensions/telegram/api.ts`:

- **3x index signature mismatch**: `call()` accepted `Record<string, unknown>` but typed interfaces (`GetFileParams`, `SendMessageParams`, `SendChatActionParams`) lack index signatures. Widened to `Record<string, unknown> | object`.
- **1x Uint8Array/BlobPart**: `new Blob([value])` where `value: Uint8Array` — TS strict rejects `Uint8Array<ArrayBufferLike>` as `BlobPart`. Added explicit cast.

No behavioral change. All 258 tests pass.