### PR TITLE
fix(heartbeat): set log-style output tone in check-in prompt

### DIFF
--- a/extensions/rho/index.ts
+++ b/extensions/rho/index.ts
@@ -1883,6 +1883,8 @@ export default function (pi: ExtensionAPI) {
     }
 
     const fullPrompt = `You are rho performing a ${force ? "manual" : "scheduled"} check-in.
+This is a background process — no user is watching. Output is a log, not a conversation.
+Write concise English. No greetings, no conversational tone.
 
 ## ${force ? "Active" : "Due"} Reminders
 ${remindersSection}


### PR DESCRIPTION
Heartbeat subagent inherits brain preferences (e.g. conversation language) and produces conversational output aimed at the user, even though nobody is watching the tmux window in real-time.

Add two lines to the heartbeat prompt establishing that this is a background process and output should be concise English log entries, not conversation.