### PR TITLE
feat(telegram): add photo and document image support

### DIFF
--- a/extensions/telegram/rpc.ts
+++ b/extensions/telegram/rpc.ts
@@ -32,6 +32,7 @@ interface PendingPrompt {
   lastAssistantText: string;
   stderrLines: string[];
   triedBusyFollowUp: boolean;
+  images?: Array<{ type: "image"; data: string; mimeType: string }>;
 }
 
 interface PendingCommandsRequest {
@@ -134,7 +135,7 @@ export class TelegramRpcRunner {
     this.spawnProcess = spawnProcess;
   }
 
-  async runPrompt(sessionFile: string, message: string, timeoutMs = 120_000): Promise<string> {
+  async runPrompt(sessionFile: string, message: string, timeoutMs = 120_000, images?: Array<{ type: "image"; data: string; mimeType: string }>): Promise<string> {
     const session = this.ensureSession(sessionFile);
     if (session.pending) {
       throw new Error(`RPC session busy for ${sessionFile}`);
@@ -172,6 +173,7 @@ export class TelegramRpcRunner {
         lastAssistantText: "",
         stderrLines: [],
         triedBusyFollowUp: false,
+        images: images?.length ? images : undefined,
       };
 
       this.sendPromptCommand(session, session.pending);
@@ -304,6 +306,7 @@ export class TelegramRpcRunner {
       type: "prompt",
       message: pending.rpcMessage,
       ...(streamingBehavior ? { streamingBehavior } : {}),
+      ...(pending.images?.length ? { images: pending.images } : {}),
     });
   }
 


### PR DESCRIPTION
Photos and images sent as documents are now downloaded, base64-encoded, and forwarded to the LLM via pi's native RPC image support.

Changes:
- router.ts: add 'photo' and 'document_image' media kinds with size-aware photo selection (selectBestPhoto picks largest variant under 5MB cap)
- rpc.ts: thread images through runPrompt -> sendPromptCommand -> RPC
- worker-runtime.ts: download with 3-retry getFile, pre/post size checks, split drain queue into image path (vision) and audio path (STT)

Behavior:
- Compressed photos (message.photo): hardcoded image/jpeg, size selection
- Document images (message.document with image/* mime): dynamic mime type
- Captionless photos get default prompt 'Describe this image.'
- Oversized photos with caption fall back to text-only prompt
- Oversized captionless photos are silently dropped
- No background deferral for images (timeout returns error)
- Mixed known/unknown photo sizes: falls back to medium resolution