### PR TITLE
feat(telegram): add message metadata prefix to prompts

### DIFF
--- a/extensions/telegram/router.ts
+++ b/extensions/telegram/router.ts
@@ -50,6 +50,7 @@ export interface TelegramInboundEnvelope {
   chatType: "private" | "group" | "supergroup" | "channel";
   userId: number | null;
   messageId: number;
+  date: number;
   text: string;
   media?: TelegramInboundMedia;
   replyToMessageId?: number;
@@ -130,6 +131,7 @@ export function normalizeInboundUpdate(update: Update): TelegramInboundEnvelope 
     chatType: message.chat.type as TelegramInboundEnvelope["chatType"],
     userId: typeof message.from?.id === "number" ? message.from.id : null,
     messageId: message.message_id,
+    date: typeof message.date === "number" ? message.date : 0,
     text,
     media,
     replyToMessageId: message.reply_to_message?.message_id,

--- a/tests/test-telegram.ts
+++ b/tests/test-telegram.ts
@@ -269,6 +269,18 @@ try {
     assert(normalized?.chatId === 777, "normalized chat id");
     assert(normalized?.userId === 42, "normalized user id");
     assert(normalized?.media === undefined, "text-only messages do not include media envelope");
+    assert(normalized?.date === 1, "normalized envelope includes message date");
+
+    const noDatedNormalized = normalizeInboundUpdate({
+      update_id: 124,
+      message: {
+        message_id: 10,
+        from: { id: 42 },
+        chat: { id: 777, type: "private" as const },
+        text: "no date field",
+      },
+    } as any);
+    assert(noDatedNormalized?.date === 0, "missing message date defaults to 0");
 
     const voiceNormalized = normalizeInboundUpdate({
       update_id: 1231,
@@ -395,6 +407,7 @@ try {
       chatType: "private" as const,
       userId: 42,
       messageId: 10,
+      date: 1,
       text: "hello",
       isReplyToBot: false,
     };


### PR DESCRIPTION
Prepend [msg:chatId:messageId] [YYYY-MM-DD HH:MM] to messages sent to the LLM, giving the model awareness of message timing and identifiers.

Changes:
- router.ts: add date field (Unix epoch) to TelegramInboundEnvelope
- worker-runtime.ts: formatMessagePrefix helper + prefixPrompt wrapper that skips slash commands (preserves ^/ anchored parsing in rpc.ts)
- Prefix applied at 5 RPC call sites (image, audio, text foreground + 2 background fork points)
- Timezone configurable via TELEGRAM_TIMESTAMP_TZ env var (default UTC)
- Backwards compatible: missing date field on queued items produces prefix without timestamp bracket