### PR TITLE
fix(sync): resolve clean-install extension and skill conflicts

### DIFF
--- a/cli/registry.ts
+++ b/cli/registry.ts
@@ -13,6 +13,8 @@ export interface ModuleEntry {
 	alwaysOn?: boolean; // core modules that cannot be disabled
 	npmPackage?: string; // external npm package name (legacy shorthand)
 	packageSource?: string; // external package source (e.g., npm:foo, git:github.com/user/repo)
+	packageExtensions?: string[]; // optional extension filter for external package modules
+	packageSkills?: string[]; // optional skill filter for external package modules
 }
 
 /**
@@ -130,6 +132,7 @@ export const REGISTRY: Record<string, ModuleEntry> = {
 		extensions: [],
 		skills: [],
 		packageSource: "git:github.com/nicobailon/visual-explainer",
+		packageSkills: ["SKILL.md"],
 		description:
 			"Generate polished HTML diagrams, reviews, and comparison tables",
 	},

--- a/cli/sync-core.ts
+++ b/cli/sync-core.ts
@@ -5,7 +5,7 @@
  * generates sync locks. All functions are pure and testable.
  */
 
-import type { PackagesConfig, RhoConfig } from "./config.ts";
+import type { PackageEntry, PackagesConfig, RhoConfig } from "./config.ts";
 import { REGISTRY } from "./registry.ts";
 
 // ---- Types ----
@@ -79,7 +79,14 @@ export function collectExternalModulePackages(
 		const enabled = catModules[name] === true;
 
 		if (enabled) {
-			entries.push({ source });
+			const entry: PackageEntry = { source };
+			if (Array.isArray(reg.packageExtensions)) {
+				entry.extensions = [...reg.packageExtensions];
+			}
+			if (Array.isArray(reg.packageSkills)) {
+				entry.skills = [...reg.packageSkills];
+			}
+			entries.push(entry);
 		}
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ memory = true         # Memory browser and viewer
 vault = true          # Knowledge vault with FTS and orphan cleanup
 
 [modules.tools]
-brave-search = true      # Web search via Brave API
+brave-search = true      # Brave Search extension (/brave-search command, brave_search tool)
 x-search = true          # X/Twitter search via xAI Grok
 telegram = true          # Telegram transport adapter
 email = false            # Agent email at name@rhobot.dev
@@ -56,7 +56,7 @@ usage-bars = true     # Token/cost usage display
 
 **Core modules are always on.** Setting `heartbeat = false` or `memory = false` has no effect — they're forced enabled. You'll get a warning from `rho sync` if you try.
 
-Some modules are backed by external packages (`subagents`, `messenger`, `interactive-shell`, `web-access`, `mcp-adapter`, `interview-tool`, `visual-explainer`). When enabled, `rho sync` installs their package sources automatically; when disabled, `rho sync` removes them.
+Some modules are backed by external packages (`subagents`, `messenger`, `interactive-shell`, `web-access`, `mcp-adapter`, `interview-tool`, `visual-explainer`). When enabled, `rho sync` installs their package sources automatically; when disabled, `rho sync` removes them. For `visual-explainer`, sync applies a `skills = ["SKILL.md"]` filter so non-skill markdown files (like README/CHANGELOG) are not treated as skills.
 
 Attribution for those default third-party modules:
 Special thanks to **Nico Bailon (@nicobailon)** for building and maintaining these packages.

--- a/extensions/brave-search/index.ts
+++ b/extensions/brave-search/index.ts
@@ -12,129 +12,149 @@ const API_KEY = process.env.BRAVE_API_KEY;
 const SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
 
 interface SearchResult {
-  title: string;
-  url: string;
-  description: string;
+	title: string;
+	url: string;
+	description: string;
 }
 
 interface BraveSearchResponse {
-  web?: {
-    results?: Array<{
-      title: string;
-      url: string;
-      description: string;
-    }>;
-  };
-  query?: {
-    original: string;
-  };
+	web?: {
+		results?: Array<{
+			title: string;
+			url: string;
+			description: string;
+		}>;
+	};
+	query?: {
+		original: string;
+	};
 }
 
 async function search(query: string, count = 5): Promise<SearchResult[]> {
-  if (!API_KEY) {
-    throw new Error("BRAVE_API_KEY not set");
-  }
+	if (!API_KEY) {
+		throw new Error("BRAVE_API_KEY not set");
+	}
 
-  const params = new URLSearchParams({
-    q: query,
-    count: String(count),
-  });
+	const params = new URLSearchParams({
+		q: query,
+		count: String(count),
+	});
 
-  const response = await fetch(`${SEARCH_URL}?${params}`, {
-    headers: {
-      Accept: "application/json",
-      "X-Subscription-Token": API_KEY,
-    },
-  });
+	const response = await fetch(`${SEARCH_URL}?${params}`, {
+		headers: {
+			Accept: "application/json",
+			"X-Subscription-Token": API_KEY,
+		},
+	});
 
-  if (!response.ok) {
-    throw new Error(`Brave Search API error: ${response.status} ${response.statusText}`);
-  }
+	if (!response.ok) {
+		throw new Error(
+			`Brave Search API error: ${response.status} ${response.statusText}`,
+		);
+	}
 
-  const data = (await response.json()) as BraveSearchResponse;
-  
-  return (data.web?.results || []).map((r) => ({
-    title: r.title,
-    url: r.url,
-    description: r.description,
-  }));
+	const data = (await response.json()) as BraveSearchResponse;
+
+	return (data.web?.results || []).map((r) => ({
+		title: r.title,
+		url: r.url,
+		description: r.description,
+	}));
 }
 
 export default function (pi: ExtensionAPI) {
-  // Register search tool
-  pi.registerTool({
-    name: "web_search",
-    label: "Web Search",
-    description: "Search the web using Brave Search. Use for finding documentation, current information, facts, or any web content.",
-    parameters: Type.Object({
-      query: Type.String({ description: "Search query" }),
-      count: Type.Optional(Type.Number({ description: "Number of results (default: 5, max: 10)" })),
-    }),
+	// Register Brave-specific search tool
+	pi.registerTool({
+		name: "brave_search",
+		label: "Brave Search",
+		description:
+			"Search the web using Brave Search. Use for finding documentation, current information, facts, or any web content.",
+		parameters: Type.Object({
+			query: Type.String({ description: "Search query" }),
+			count: Type.Optional(
+				Type.Number({ description: "Number of results (default: 5, max: 10)" }),
+			),
+		}),
 
-    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      if (!API_KEY) {
-        return {
-          content: [{ type: "text", text: "Error: BRAVE_API_KEY not set. Add to ~/.bashrc:\nexport BRAVE_API_KEY=\"your-key\"" }],
-          details: { error: true },
-        };
-      }
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			if (!API_KEY) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: 'Error: BRAVE_API_KEY not set. Add to ~/.bashrc:\nexport BRAVE_API_KEY="your-key"',
+						},
+					],
+					details: { error: true },
+				};
+			}
 
-      try {
-        const count = Math.min(params.count || 5, 10);
-        const results = await search(params.query, count);
+			try {
+				const count = Math.min(params.count || 5, 10);
+				const results = await search(params.query, count);
 
-        if (results.length === 0) {
-          return {
-            content: [{ type: "text", text: `No results for: ${params.query}` }],
-            details: { query: params.query, count: 0 },
-          };
-        }
+				if (results.length === 0) {
+					return {
+						content: [
+							{ type: "text", text: `No results for: ${params.query}` },
+						],
+						details: { query: params.query, count: 0 },
+					};
+				}
 
-        const formatted = results
-          .map((r, i) => `${i + 1}. **${r.title}**\n   ${r.url}\n   ${r.description}`)
-          .join("\n\n");
+				const formatted = results
+					.map(
+						(r, i) =>
+							`${i + 1}. **${r.title}**\n   ${r.url}\n   ${r.description}`,
+					)
+					.join("\n\n");
 
-        return {
-          content: [{ type: "text", text: formatted }],
-          details: { query: params.query, count: results.length },
-        };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: "text", text: `Search error: ${message}` }],
-          details: { error: true, message },
-        };
-      }
-    },
-  });
+				return {
+					content: [{ type: "text", text: formatted }],
+					details: { query: params.query, count: results.length },
+				};
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return {
+					content: [{ type: "text", text: `Search error: ${message}` }],
+					details: { error: true, message },
+				};
+			}
+		},
+	});
 
-  // Register /search command for user
-  pi.registerCommand("search", {
-    description: "Quick web search (usage: /search <query>)",
-    handler: async (args, ctx) => {
-      if (!args?.trim()) {
-        ctx.ui.notify("Usage: /search <query>", "error");
-        return;
-      }
+	// Register /brave-search command for user
+	pi.registerCommand("brave-search", {
+		description: "Quick Brave web search (usage: /brave-search <query>)",
+		handler: async (args, ctx) => {
+			if (!args?.trim()) {
+				ctx.ui.notify("Usage: /brave-search <query>", "error");
+				return;
+			}
 
-      if (!API_KEY) {
-        ctx.ui.notify("BRAVE_API_KEY not set", "error");
-        return;
-      }
+			if (!API_KEY) {
+				ctx.ui.notify("BRAVE_API_KEY not set", "error");
+				return;
+			}
 
-      try {
-        const results = await search(args.trim(), 3);
-        if (results.length === 0) {
-          ctx.ui.notify("No results", "info");
-        } else {
-          ctx.ui.notify(`Found ${results.length} results`, "success");
-          // Set results in editor for easy use
-          const text = results.map((r) => `- [${r.title}](${r.url})`).join("\n");
-          ctx.ui.setEditorText(text);
-        }
-      } catch (err) {
-        ctx.ui.notify(`Error: ${err instanceof Error ? err.message : err}`, "error");
-      }
-    },
-  });
+			try {
+				const results = await search(args.trim(), 3);
+				if (results.length === 0) {
+					ctx.ui.notify("No results", "info");
+				} else {
+					ctx.ui.notify(`Found ${results.length} results`, "success");
+					// Set results in editor for easy use
+					const text = results
+						.map((r) => `- [${r.title}](${r.url})`)
+						.join("\n");
+					ctx.ui.setEditorText(text);
+				}
+			} catch (err) {
+				ctx.ui.notify(
+					`Error: ${err instanceof Error ? err.message : err}`,
+					"error",
+				);
+			}
+		},
+	});
 }

--- a/templates/init.toml
+++ b/templates/init.toml
@@ -24,7 +24,7 @@ memory = true                         # Memory browser and viewer
 vault = true                          # Knowledge vault with full-text search and orphan cleanup
 
 [modules.tools]
-brave-search = true                   # Web search via Brave Search API
+brave-search = true                   # Web search via Brave Search API (/brave-search command, brave_search tool)
 x-search = true                       # X/Twitter search via xAI Grok
 telegram = true                       # Telegram channel adapter for chatting with your agent
 email = false                         # Agent email via Rho Cloud (rhobot.dev)

--- a/tests/test-sync.ts
+++ b/tests/test-sync.ts
@@ -363,6 +363,14 @@ console.log("\n-- collectExternalModulePackages: enabled modules --");
 		],
 		"collects default external package sources",
 	);
+	const visual = entries.find(
+		(entry) => entry.source === "git:github.com/nicobailon/visual-explainer",
+	);
+	assertEq(
+		visual?.skills,
+		["SKILL.md"],
+		"visual-explainer applies SKILL.md filter",
+	);
 }
 
 console.log("\n-- collectExternalModulePackages: disabled modules omitted --");


### PR DESCRIPTION
## Summary
Fixes the clean-install warnings reported in #29 by addressing the actual root causes instead of suppressing modules.

### What changed

1. **Resolve brave-search / web-access collision without disabling defaults**
   - `extensions/brave-search/index.ts`
   - Renamed Brave extension registrations to avoid namespace collision with `pi-web-access`:
     - tool: `web_search` -> `brave_search`
     - command: `/search` -> `/brave-search`

2. **Filter visual-explainer package to SKILL.md only**
   - `cli/registry.ts`
   - `cli/sync-core.ts`
   - Added optional external package filters in registry entries:
     - `packageExtensions?: string[]`
     - `packageSkills?: string[]`
   - Applied `packageSkills: ["SKILL.md"]` to `visual-explainer` so README/CHANGELOG are not treated as skills.

3. **Add clean-startup runtime guardrails in E2E**
   - `tests/e2e/test-e2e.sh`
   - `tests/e2e/test-npm-install.sh`
   - Added runtime checks after sync to ensure `pi --help` does **not** emit:
     - `conflicts with`
     - `Skill conflicts`
     - `description is required`

4. **Docs/template alignment**
   - `templates/init.toml`
   - `docs/configuration.md`
   - Kept defaults aligned with PR #28 intent (`brave-search = true`, `web-access = true`, `visual-explainer = true`) and documented the new semantics.

## Why this approach
- Preserves the batteries-included defaults introduced in PR #28.
- Eliminates extension/tool collisions by namespacing Brave registrations.
- Eliminates visual-explainer skill warnings by explicit package filtering.
- Prevents regressions by adding runtime startup checks in E2E (not just dry-run planning checks).

## Validation
- `node --experimental-strip-types tests/test-config.ts`
- `node --experimental-strip-types tests/test-sync.ts`
- `node --experimental-strip-types tests/test-templates.ts`
- `node --experimental-strip-types tests/test-init.ts`
- `node --experimental-strip-types tests/test-registry.ts`
- `npx biome check --error-on-warnings cli/registry.ts cli/sync-core.ts extensions/brave-search/index.ts tests/test-sync.ts`

Also verified with fresh HOME install flow:
- `rho init`
- `rho sync`
- `pi --help` and `pi --print "hello"`
- No extension conflict warnings and no visual-explainer skill warnings.

Fixes #29
