### PR TITLE
fix(telegram): race condition in cancelSession kills replacement RPC process

### DIFF
--- a/extensions/telegram/rpc.ts
+++ b/extensions/telegram/rpc.ts
@@ -46,6 +46,7 @@ interface RpcSessionState {
   process: ChildProcessWithoutNullStreams;
   buffer: string;
   connected: boolean;
+  exited: boolean;
   pending: PendingPrompt | null;
   commandIndex: Map<string, SlashCommandEntry>;
   commandsLoaded: boolean;
@@ -207,13 +208,11 @@ export class TelegramRpcRunner {
     }
 
     setTimeout(() => {
-      const current = this.sessions.get(sessionFile);
-      if (!current) return;
-      if (current.process.killed) return;
+      if (session.exited) return;
       try {
-        current.process.kill("SIGKILL");
+        session.process.kill("SIGKILL");
       } catch {
-        // ignore
+        // ignore — process may have exited between check and kill
       }
     }, 2_000);
 
@@ -222,7 +221,7 @@ export class TelegramRpcRunner {
 
   private ensureSession(sessionFile: string): RpcSessionState {
     const existing = this.sessions.get(sessionFile);
-    if (existing && !existing.process.killed) return existing;
+    if (existing && !existing.exited) return existing;
 
     const child = this.spawnProcess("pi", ["--mode", "rpc"], {
       stdio: ["pipe", "pipe", "pipe"],
@@ -240,6 +239,7 @@ export class TelegramRpcRunner {
       process: child,
       buffer: "",
       connected: false,
+      exited: false,
       pending: null,
       commandIndex: new Map(),
       commandsLoaded: false,
@@ -271,6 +271,7 @@ export class TelegramRpcRunner {
     });
 
     child.once("exit", (code, signal) => {
+      state.exited = true;
       if (state.pending) {
         this.rejectPending(state, `RPC exited (code=${code ?? "null"}, signal=${signal ?? "null"})`);
       }


### PR DESCRIPTION
## Problem

When a Telegram prompt exceeds the 60s foreground timeout, the worker forks it to a background job. This calls `cancelSession()` on the old RPC process, then `ensureSession()` spawns a replacement process for the background job.

`cancelSession()` sends SIGTERM immediately, then schedules a SIGKILL fallback after 2 seconds via `setTimeout`. The SIGKILL callback looks up the process **by `sessionFile` key** in the `sessions` Map:

```typescript
setTimeout(() => {
  const current = this.sessions.get(sessionFile); // ← stale lookup
  if (!current) return;
  if (current.process.killed) return;
  current.process.kill('SIGKILL'); // ← kills the NEW process!
}, 2_000);
```

By the time the timer fires, `ensureSession()` has already spawned a **replacement** process under the same key — so SIGKILL kills the new process instead of the old one.

**Timeline of the race:**
1. `cancelSession(oldFile)` → SIGTERM old process, schedule SIGKILL in 2s
2. Old process exits → `sessions.delete(oldFile)` in exit handler
3. Background job starts → `ensureSession(oldFile)` spawns new process → `sessions.set(oldFile, newProcess)`
4. 2s timer fires → `sessions.get(oldFile)` → finds **new** process → **SIGKILL** 💥

**User sees:** `⚠️ Failed to run prompt: RPC exited (code=null, signal=SIGKILL)`

This is reproducible on fast machines where the replacement process starts within 2 seconds. This is the same class of bug that was fixed for the web RPC manager in PR #16.

## Fix

Three changes to `extensions/telegram/rpc.ts`:

1. **Capture direct process reference** in `cancelSession()` instead of re-looking it up from the Map in the setTimeout callback
2. **Add `exited` flag** to `RpcSessionState` (set in the exit handler) to reliably guard the SIGKILL escalation — replacing the unreliable `process.killed` check (which is `true` when the signal is *sent*, not when the process *exits*)
3. **Use `exited` flag** in `ensureSession()` for the same reason

## Log evidence

```
09:59:49.939  rpc_prompt_background_started  job_id=JMM65GKOIKNSX
09:59:51.962  rpc_prompt_background_error     error="RPC exited (code=null, signal=SIGKILL)"
```

The 2-second gap between start and SIGKILL matches the `setTimeout(..., 2_000)` timer exactly.