### PR TITLE
fix(web): handle fire-and-forget extension UI methods in web UI

### DIFF
--- a/web/public/js/chat/chat-model-and-extension-ui.js
+++ b/web/public/js/chat/chat-model-and-extension-ui.js
@@ -3,6 +3,12 @@ import * as modelThinking from "./model-thinking-and-toast.js";
 import * as renderingUsage from "./rendering-and-usage.js";
 import * as toolSemantics from "./tool-semantics.js";
 
+// biome-ignore lint: ANSI escape code pattern is intentionally complex
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
+function stripAnsi(text) {
+	return typeof text === "string" ? text.replace(ANSI_RE, "") : text;
+}
+
 const {
 	slashContract,
 	toFiniteNumber,
@@ -299,7 +305,7 @@ export const rhoChatModelAndExtensionMethods = {
 		// Fire-and-forget extension UI methods (no response expected)
 		if (method === "notify") {
 			this.showToast(
-				request.message ?? request.text ?? "",
+				stripAnsi(request.message ?? request.text ?? ""),
 				request.notifyType ?? request.level ?? "info",
 				request.duration,
 			);
@@ -307,7 +313,9 @@ export const rhoChatModelAndExtensionMethods = {
 		}
 
 		if (method === "setStatus") {
-			this.extensionStatus = request.statusText ?? request.text ?? "";
+			this.extensionStatus = stripAnsi(
+				request.statusText ?? request.text ?? "",
+			);
 			this.updateFooter();
 			return;
 		}

--- a/web/public/js/chat/chat-rpc-event-routing.js
+++ b/web/public/js/chat/chat-rpc-event-routing.js
@@ -1,6 +1,12 @@
 import * as primitives from "./constants-and-primitives.js";
 import * as modelThinking from "./model-thinking-and-toast.js";
 import * as renderingUsage from "./rendering-and-usage.js";
+
+// biome-ignore lint: ANSI escape code pattern is intentionally complex
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
+function stripAnsi(text) {
+	return typeof text === "string" ? text.replace(ANSI_RE, "") : text;
+}
 import {
 	recoverSessionByFile,
 	replayPendingRpcCommandsForSession,
@@ -454,7 +460,7 @@ export const rhoChatRpcEventMethods = {
 		// Fire-and-forget extension events
 		if (event.type === "notify" || event.type === "extension_notify") {
 			this.showToast(
-				event.message ?? event.text ?? "",
+				stripAnsi(event.message ?? event.text ?? ""),
 				event.level ?? "info",
 				event.duration,
 			);
@@ -462,7 +468,7 @@ export const rhoChatRpcEventMethods = {
 		}
 
 		if (event.type === "setStatus" || event.type === "extension_status") {
-			this.extensionStatus = event.text ?? event.message ?? "";
+			this.extensionStatus = stripAnsi(event.text ?? event.message ?? "");
 			this.updateFooter();
 			return;
 		}


### PR DESCRIPTION
## Problem

When extensions call `ctx.ui.notify()`, `ctx.ui.setStatus()`, `ctx.ui.setWidget()`, or `ctx.ui.setTitle()` in RPC mode, pi emits `extension_ui_request` events with the corresponding method name. The web UI's `handleExtensionUIRequest` only handled dialog methods (`select`, `confirm`, `input`, `editor`) and silently dropped fire-and-forget methods.

**Result:** `ctx.ui.notify('Usage refreshed')` from e.g. the usage-bars extension shows nothing in the web UI, even though toast infrastructure (`showToast`) and status bar (`extensionStatus`) already exist and work for top-level event types.

The RPC TUI example (`examples/rpc-extension-ui.ts`) correctly handles all these methods (lines 426-458), confirming they are part of the extension UI protocol.

## Fix

Add handlers for `notify`, `setStatus`, `setWidget`, and `setTitle` in `handleExtensionUIRequest`, delegating to existing UI primitives:

| Method | RPC fields | Web UI action |
|--------|-----------|---------------|
| `notify` | `message`, `notifyType`/`level`, `duration` | `showToast()` |
| `setStatus` | `statusText` | `extensionStatus` + `updateFooter()` |
| `setWidget` | `widgetLines` | `extensionWidget` |
| `setTitle` | `title`/`text` | `document.title` |

## Testing

Verified that `/usage` command now shows a toast notification in the web UI.