### PR TITLE
feat(web): user stylesheet hook via ~/.rho/user.css

### DIFF
--- a/web/server-static-routes.ts
+++ b/web/server-static-routes.ts
@@ -9,11 +9,34 @@ import {
 	rpcReliability,
 	rpcSessionSubscribers,
 } from "./server-core.ts";
+import { getRhoHome } from "./config.ts";
+
+// --- User CSS ---
+
+const USER_CSS_PATH = path.join(getRhoHome(), "user.css");
+const USER_CSS_LINK = '<link rel="stylesheet" href="/user.css">';
+
+app.get("/user.css", async (c) => {
+	try {
+		const css = await readFile(USER_CSS_PATH, "utf-8");
+		c.header("Content-Type", "text/css");
+		c.header("Cache-Control", "no-cache");
+		return c.body(css);
+	} catch {
+		return c.body("", 404);
+	}
+});
 
 // --- Static files ---
 
 app.get("/", async (c) => {
-	const html = await readFile(path.join(publicDir, "index.html"), "utf-8");
+	let html = await readFile(path.join(publicDir, "index.html"), "utf-8");
+	try {
+		await readFile(USER_CSS_PATH, "utf-8");
+		html = html.replace("</head>", `${USER_CSS_LINK}\n</head>`);
+	} catch {
+		// No user.css — serve unmodified
+	}
 	return c.html(html);
 });
 


### PR DESCRIPTION
## Summary

Adds a zero-config way to inject custom CSS into the rho web UI. If `~/.rho/user.css` exists it is served at `GET /user.css` and injected into the root HTML. If it does not exist, both paths are no-ops — no behaviour change for existing users.

## What changed

### Static route + injection (`web/server-static-routes.ts`)
- Added `GET /user.css` route — reads `~/.rho/user.css`, returns 404 silently if absent, served with `Cache-Control: no-cache`
- Modified `GET /` to inject `<link rel="stylesheet" href="/user.css">` when the file exists
- Imported `getRhoHome` from `./config.ts` (already exported, no new dependency)

### diff stat
```
web/server-static-routes.ts | 25 ++++++++++++++++++++++++-
1 file changed, 24 insertions(+), 1 deletion(-)
```

## Testing

Drop a `~/.rho/user.css` (e.g. the Catppuccin Mocha example below), run `rho web`, open `http://localhost:3141` — theme applies without a server restart.

```css
/* ~/.rho/user.css — Catppuccin Mocha example */
:root {
  --bg: #1e1e2e;
  --bg-alt: #181825;
  --border: #313244;
  --border-bright: #45475a;
  --text: #cdd6f4;
  --text-muted: #7f849c;
  --green: #a6e3a1;
  --green-dim: #40a02b;
  --cyan: #89dceb;
  --mono: "JetBrains Mono", monospace;
}
```

Remove the file and reload — UI returns to defaults. No errors logged either way.

## Backward compatibility

- Existing users with no `~/.rho/user.css` see zero behaviour change.
- `rho upgrade` no longer clobbers custom themes; the file lives in `~/.rho/` alongside `init.toml` and `brain/`.