### PR TITLE
fix: address issues #39 and #40 — multi-part model IDs + localhost display

### DIFF
--- a/extensions/lib/auto-memory-model.ts
+++ b/extensions/lib/auto-memory-model.ts
@@ -50,7 +50,7 @@ function normalizeConfiguredModel(
 	}
 
 	const parts = trimmed.split("/");
-	if (parts.length !== 2 || !parts[0] || !parts[1]) {
+	if (parts.length < 2 || !parts[0] || !parts.slice(1).every((p) => p)) {
 		return {
 			kind: "invalid",
 			requestedModel: trimmed,
@@ -62,7 +62,7 @@ function normalizeConfiguredModel(
 		kind: "configured",
 		requestedModel: trimmed,
 		provider: parts[0],
-		id: parts[1],
+		id: parts.slice(1).join("/"),
 	};
 }
 

--- a/web/dev.ts
+++ b/web/dev.ts
@@ -2,11 +2,11 @@ import { serve } from "@hono/node-server";
 import app, { disposeServerResources, injectWebSocket } from "./server.ts";
 
 const port = 3141;
-const hostname = "0.0.0.0";
+const bindHost = "0.0.0.0";
 
-const server = serve({ fetch: app.fetch, port, hostname });
+const server = serve({ fetch: app.fetch, port, hostname: bindHost });
 injectWebSocket(server);
-console.log(`Rho web server listening on http://${hostname}:${port}`);
+console.log(`Rho web server listening on http://localhost:${port}`);
 
 function shutdown(signal: string): void {
   console.log(`Shutting down web server (${signal})...`);


### PR DESCRIPTION
## Summary
- Support OpenRouter-style model IDs (e.g. `openrouter/openai/gpt-5.4-mini`) in `auto_memory_model` config by accepting any number of slashes instead of strictly 2 parts
- Fix ``rho web`` startup message to show ``localhost:3141`` while keeping the actual bind address as ``0.0.0.0``

## Changes
- **extensions/lib/auto-memory-model.ts**: Changed validation from strict 2-part split to flexible multi-part split. Provider is always the first segment; model ID is everything after the first slash.
- **web/dev.ts**: Separated display hostname (localhost) from bind address (0.0.0.0).

## Validation
- Manual review of diff — no new dependencies, no API changes
- Pre-existing linter errors are unrelated (missing node_modules)
- The auto-memory-model change is backward compatible: `openai/gpt-4` still works the same way

Closes #39, Closes #40